### PR TITLE
Bug# 22865112 LACK OF HTONLL CHECK CAUSE MYSQ5.6.30/5.7.12 BUILD FAIL…

### DIFF
--- a/plugin/innodb_memcached/daemon_memcached/include/memcached/util.h
+++ b/plugin/innodb_memcached/daemon_memcached/include/memcached/util.h
@@ -1,3 +1,5 @@
+/* Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved. */
+
 #ifndef UTIL_H
 #define UTIL_H
 /*
@@ -11,6 +13,11 @@
  */
 #include <memcached/visibility.h>
 #include <memcached/types.h>
+
+/* Changed for INNODB_MEMCACHED */
+#if defined(htonll)
+#define HAVE_HTONLL 1
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
…URE ON OS X

PROBLEM
-------

Build failure in some mac machines due to redefinition of htonll function.

FIX
---
Introduced a check to not redefine htonll if OS provides htonll function.

(cherry picked from commit 4b47067d6e74a5493d0604afed3d852d03092771)